### PR TITLE
Get real commit branch instead of the currently active one.

### DIFF
--- a/git-to-freshports/git-to-freshports-xml.py
+++ b/git-to-freshports/git-to-freshports-xml.py
@@ -146,7 +146,16 @@ def main():
         ET.SubElement(update, 'TIME', Timezone='UTC', Hour=str(commit_datetime.hour),
                       Minute=str(commit_datetime.minute), Second=str(commit_datetime.second))
         log.debug("Writing OS entry")
-        ET.SubElement(update, 'OS', Repo=config['repo'], Id=config['os'], Branch=str(repo.head.shorthand))
+        commit_branches = list(repo.branches.local.with_commit(commit))
+        commit_branches_num = len(commit_branches)
+        if commit_branches_num == 0:
+            log.error(f"Unable to get branch name for commit {commit.hex}. "
+                      f"Make sure that the local tracking branch exists for the remote branch.")
+            continue
+        elif commit_branches_num > 1:
+            log.warning(f"Ambiguity in getting branch name for commit {commit.hex}. Got branches: {commit_branches}."
+                        f"Using the first one: {commit_branches[0]}")
+        ET.SubElement(update, 'OS', Repo=config['repo'], Id=config['os'], Branch=commit_branches[0])
 
         log.debug("Writing commit message")
         text = ET.SubElement(update, 'LOG')


### PR DESCRIPTION
Previously it was assumed that the commit being processed is a member
of the currently active branch, which may not be the case.

This commit changes the behavior so that each time a commit is
processed - it's branches are got from the git tree. The first
found branch is used as a comit branch.

For this functionality to function properly - remote branches from
which the commits may be processed have to be checked out locally
beforehand using `git checkout -b <branch_name>`.

Finding the branch name for a specific commit is slow process which
can substantially increase the commit processing times.

Closes #32.