### PR TITLE
Ignore merged branches' commits while walking the tree

### DIFF
--- a/git-to-freshports/git-to-freshports-xml.py
+++ b/git-to-freshports/git-to-freshports-xml.py
@@ -121,8 +121,11 @@ def commit_range(repo: pygit2.Repository, commit_range: str):
     start_commit = repo.revparse_single(start_commit_ref)
     end_commit   = repo.revparse_single(end_commit_ref)
 
+    walker = repo.walk(end_commit.oid)
+    walker.simplify_first_parent()  # Avoid wandering off to merged branches. Same as 'git log --first-parent'
+
     result = []
-    for commit in repo.walk(end_commit.oid):
+    for commit in walker:
         if commit == start_commit:
             break
         result.append(commit)


### PR DESCRIPTION
Command:
```
$ python git-to-freshports-xml.py --repo src --path src --commit 0db6aef407f --spooling spool --output out -v --log-dest stderr
```

Result before:
```
$ ls out | wc -l
180
```

Result after:
```
$ ls out | wc -l
178
```

Resolves #35 